### PR TITLE
hotfix-getproducts-api: Fix response of getProducts api, add example api value

### DIFF
--- a/Pos-System/Controllers/ProductController.cs
+++ b/Pos-System/Controllers/ProductController.cs
@@ -11,6 +11,7 @@ using Pos_System.API.Payload.Response.Products;
 using Pos_System.API.Services.Implements;
 using Pos_System.API.Services.Interfaces;
 using Pos_System.API.Validators;
+using Pos_System.Domain.Paginate;
 
 namespace Pos_System.API.Controllers
 {
@@ -41,6 +42,7 @@ namespace Pos_System.API.Controllers
 
         [CustomAuthorize(RoleEnum.BrandAdmin)]
         [HttpGet(ApiEndPointConstant.Product.ProductsEndPoint)]
+        [ProducesResponseType(typeof(IPaginate<GetProductResponse>), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetProducts([FromQuery] string? name, [FromQuery] ProductType? type, [FromQuery] int page, [FromQuery] int size)
         {
             var productsResponse = await _productService.GetProducts(name, type, page, size);
@@ -75,6 +77,7 @@ namespace Pos_System.API.Controllers
 
         [CustomAuthorize(RoleEnum.BrandAdmin)]
         [HttpGet(ApiEndPointConstant.Product.ProductsInBrandEndPoint)]
+        [ProducesResponseType(typeof(GetProductDetailsResponse), StatusCodes.Status200OK)]
         public async Task<IActionResult> GetProductsInBrand(Guid id){
             var response = await _productService.GetProductsInBrand(id);
             return Ok(response);

--- a/Pos-System/Payload/Response/Products/GetProductResponse.cs
+++ b/Pos-System/Payload/Response/Products/GetProductResponse.cs
@@ -11,6 +11,10 @@ namespace Pos_System.API.Payload.Response.Products
         public string Code { get; set; }
         public string Name { get; set; }
         public string? PicUrl { get; set; }
+        public double? SellingPrice { get; set; }
+        public double DiscountPrice { get; set; }
+        public double HistoricalPrice { get; set; }
+
         public ProductStatus Status { get; set; }
         public ProductType Type { get; set; }
         public GetProductResponse(Guid id, string code, string name, string picUrl, string status, string type)
@@ -19,6 +23,19 @@ namespace Pos_System.API.Payload.Response.Products
             Code = code;
             Name = name;
             PicUrl = picUrl;
+            Status = EnumUtil.ParseEnum<ProductStatus>(status);
+            Type = EnumUtil.ParseEnum<ProductType>(type);
+        }
+
+        public GetProductResponse(Guid id, string code, string name, string picUrl, double sellingPrice, double discountPrice, double historicalPrice, string status, string type)
+        {
+            Id = id;
+            Code = code;
+            Name = name;
+            PicUrl = picUrl;
+            SellingPrice = sellingPrice;
+            DiscountPrice = discountPrice;
+            HistoricalPrice = historicalPrice;
             Status = EnumUtil.ParseEnum<ProductStatus>(status);
             Type = EnumUtil.ParseEnum<ProductType>(type);
         }

--- a/Pos-System/Services/Implements/ProductService.cs
+++ b/Pos-System/Services/Implements/ProductService.cs
@@ -63,7 +63,7 @@ namespace Pos_System.API.Services.Implements
             name = name?.Trim();
             if (brandId == Guid.Empty) throw new BadHttpRequestException(MessageConstant.Brand.EmptyBrandIdMessage);
             IPaginate<GetProductResponse> productsResponse = await _unitOfWork.GetRepository<Product>().GetPagingListAsync(
-                selector: x => new GetProductResponse(x.Id, x.Code, x.Name, x.PicUrl, x.Status, x.Type),
+                selector: x => new GetProductResponse(x.Id, x.Code, x.Name, x.PicUrl, x.SellingPrice, x.DiscountPrice, x.HistoricalPrice, x.Status, x.Type),
                 predicate: string.IsNullOrEmpty(name) && (type == null)
                     ? x => x.BrandId.Equals(brandId)
                     : ((type == null)


### PR DESCRIPTION
New Response:
```JSON
{
  "size": 0,
  "page": 0,
  "total": 0,
  "totalPages": 0,
  "items": [
    {
      "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
      "code": "string",
      "name": "string",
      "picUrl": "string",
      "sellingPrice": 0,
      "discountPrice": 0,
      "historicalPrice": 0,
      "status": "Active",
      "type": "SINGLE"
    }
  ]
}
```