### PR TITLE
[No Jira] Make update products in menu to able to update only with id

### DIFF
--- a/Pos-System/Payload/Request/Menus/UpdateMenuProductsRequest.cs
+++ b/Pos-System/Payload/Request/Menus/UpdateMenuProductsRequest.cs
@@ -10,7 +10,7 @@ namespace Pos_System.API.Payload.Request.Menus
     public class ProductToUpdate
     {
         public Guid ProductId { get; set; }
-        public double SellingPrice { get; set; }
-        public double DiscountPrice { get; set; }
+        public double? SellingPrice { get; set; }
+        public double? DiscountPrice { get; set; }
     }
 }

--- a/Pos-System/Services/Implements/MenuService.cs
+++ b/Pos-System/Services/Implements/MenuService.cs
@@ -169,8 +169,8 @@ namespace Pos_System.API.Services.Implements
                     {
                         Id = Guid.NewGuid(),
                         Status = ProductStatus.Active.GetDescriptionFromEnum(),
-                        SellingPrice = x.SellingPrice,
-                        DiscountPrice = x.DiscountPrice,
+                        SellingPrice = (double)(x.SellingPrice == null ? referenceProductData.SellingPrice : x.SellingPrice),
+                        DiscountPrice = (double)(x.DiscountPrice == null ? referenceProductData.DiscountPrice : x.DiscountPrice),
                         HistoricalPrice = referenceProductData.SellingPrice,
                         MenuId = menuId,
                         ProductId = x.ProductId,
@@ -193,8 +193,8 @@ namespace Pos_System.API.Services.Implements
                 {
                     ProductToUpdate requestProductData = productDataFromRequest.Find(y => y.ProductId.Equals(x.ProductId));
                     if (requestProductData == null) return;
-                    x.SellingPrice = requestProductData.SellingPrice;
-                    x.DiscountPrice = requestProductData.DiscountPrice;
+                    x.SellingPrice = (double)(requestProductData.SellingPrice == null ? x.SellingPrice : requestProductData.SellingPrice);
+                    x.DiscountPrice = (double)(requestProductData.DiscountPrice == null ? x.DiscountPrice : requestProductData.DiscountPrice);
                     x.UpdatedBy = currentUserName;
                     x.UpdatedAt = currentTime;
                 });


### PR DESCRIPTION
Make update products in menu to able to update only with id

{
  "products": [
    {
      "productId": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
    }
  ]
}