### PR TITLE
PST-133: fix api create store, map brand base menu to store

### DIFF
--- a/Pos-System/Payload/Request/Stores/CreateNewStoreRequest.cs
+++ b/Pos-System/Payload/Request/Stores/CreateNewStoreRequest.cs
@@ -8,10 +8,15 @@ namespace Pos_System.API.Payload.Request.Stores
         [Required(ErrorMessage = "Store name is required")]
         [MaxLength(50, ErrorMessage = "Store's name max length is 50 characters")]
         public string Name { get; set; }
+        [Required(ErrorMessage = "Short name is required")]
+        [MaxLength(30, ErrorMessage = "Store's short name max length is 50 characters")]
         public string? ShortName { get; set; }
         [EmailAddress(ErrorMessage = "Invalid Email")]
+        [Required(ErrorMessage = "Store's email is required")]
         public string Email { get; set; }
+        [Required(ErrorMessage = "Store's phone is required")]
         public string? Phone { get; set; }
+        [Required(ErrorMessage = "Store's code is required")]
         public string? Code { get; set; }
         [Required(ErrorMessage = "Brand id is required")]
         public Guid BrandId { get; set; }

--- a/Pos-System/Payload/Request/Stores/CreateNewStoreRequest.cs
+++ b/Pos-System/Payload/Request/Stores/CreateNewStoreRequest.cs
@@ -9,7 +9,7 @@ namespace Pos_System.API.Payload.Request.Stores
         [MaxLength(50, ErrorMessage = "Store's name max length is 50 characters")]
         public string Name { get; set; }
         [Required(ErrorMessage = "Short name is required")]
-        [MaxLength(30, ErrorMessage = "Store's short name max length is 50 characters")]
+        [MaxLength(30, ErrorMessage = "Store's short name max length is 30 characters")]
         public string? ShortName { get; set; }
         [EmailAddress(ErrorMessage = "Invalid Email")]
         [Required(ErrorMessage = "Store's email is required")]


### PR DESCRIPTION
Fix api create store, map base menu to new store when base menu is existed
Endpoint: /api/v1/stores (POST)
Request:
```Json
{
  "name": "string",
  "shortName": "string",
  "email": "user@example.com",
  "phone": "string",
  "code": "string",
  "brandId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
  "address": "string"
}
```

response:
```JSON
{
  "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
  "name": "string",
  "shortName": "string",
  "email": "string",
  "phone": "string",
  "code": "string",
  "status": "Active",
  "brandId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
  "address": "string"
}
```